### PR TITLE
Add report skeleton

### DIFF
--- a/pages/reports/[reportId].tsx
+++ b/pages/reports/[reportId].tsx
@@ -1,0 +1,59 @@
+import React, { useState } from 'react';
+import Image from 'next/image';
+import { Col, Typography, Row, Space } from 'antd';
+import { useRouter } from 'next/router';
+
+// TODO this will probably be replaced with a type from Prisma, just leaving it here for now
+const { Title, Text } = Typography;
+type Report = {
+  reportName: string;
+  reportSummary: string;
+  state: string;
+  ageLevel: string;
+  opioidGraphUrl: string;
+  medicareGraphUrl: string;
+};
+
+const Report = () => {
+  const router = useRouter();
+  // Need to use this to set report and set type to be Report | null
+  const [report, setReport] = useState<Report>({
+    reportName: 'fakeReportName',
+    reportSummary: 'fakeSummary',
+    state: 'Alaska',
+    ageLevel: 'All',
+    opioidGraphUrl: '',
+    medicareGraphUrl: ''
+  });
+  // Need to use this to get the data.
+  const { reportId } = router.query;
+
+  const { reportName, reportSummary, state, ageLevel, opioidGraphUrl, medicareGraphUrl } = report;
+  return (
+    <Row>
+      <Col span={24}>
+        <Title level={3}>Report Name: {reportName}</Title>
+      </Col>
+      <Col span={24}>
+        <Space direction="vertical">
+          <Title level={3}>State: {state}</Title>
+          <Title level={3}>Age Level: {ageLevel}</Title>
+        </Space>
+      </Col>
+      <Col span={24}>
+        <Space direction="vertical">
+          <Title level={3}>Summary:</Title>
+          <Text>{reportSummary}</Text>
+        </Space>
+      </Col>
+      <Col span={24}>
+        <Image src={opioidGraphUrl} alt="Graph of opioid rates" />
+      </Col>
+      <Col span={24}>
+        <Image src={medicareGraphUrl} alt="Graph of medicare" />
+      </Col>
+    </Row>
+  );
+};
+
+export default Report;


### PR DESCRIPTION
Add skeleton component of a report that a user would view.

This contains all the info from the db such as summary, name, state, and the graphs.
Added TODOs on things that would need to change after we get the data from the api.

SS:
<img width="1758" alt="Screen Shot 2022-09-10 at 9 28 35 PM" src="https://user-images.githubusercontent.com/99224056/189512857-b3c89960-1cf6-4f3d-8edc-2368d6ae0d6e.png">
